### PR TITLE
Ticket#0001 "ao criar artigos, define o usuario logado como o autor"

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -29,6 +29,7 @@ class ArticlesController < ApplicationController
   def create
     @article = Article.new(article_params)
     @article.user = current_user
+    @article.autor = current_user.username
 
     if @article.save
       flash[:success] = "Artigo criado com sucesso"
@@ -65,7 +66,7 @@ class ArticlesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def article_params
-      params.require(:article).permit(:title, :description, :autor, category_ids: [])
+      params.require(:article).permit(:title, :description, category_ids: [])
     end
 
     def require_same_user

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -23,14 +23,14 @@
       </div>
     </div>
 
-    <div class="form-group">
+<!-- <div class="form-group">
       <div class="control-label col-sm-2">
         <%= form.label :autor %>
       </div>
       <div class="col-sm-8">
         <%= form.text_area :autor, class: "form-control", placeholder: "Autor do artigo", autofocus: true %>
       </div>
-    </div>
+    </div> -->
 
     <div class="form-group">
       <div class="col-sm-offset-2 col-sm-10">


### PR DESCRIPTION
O que fez?
- Remoção do 'text_area' do formulário de criação de artigos que recebia o nome do autor.
- Definindo no controlador de artigos o autor como o nome do usuário logado.